### PR TITLE
Incl Win11 term for channels

### DIFF
--- a/docs/Issues.html
+++ b/docs/Issues.html
@@ -79,7 +79,7 @@
           "--release-type": {
               "name": "--release-type",
               "description": "WSA Release Channel.",
-              "detailedinfo": "RP means Release Preview, WIS means Insider Slow, WIF means Insider Fast.",
+              "detailedinfo": "RP means Release Preview, WIS means Insider Slow (Beta), WIF means Insider Fast (Dev).",
               "required": true,
               "default": "retail",
               "type": "choice",


### PR DESCRIPTION
Win11 uses channel name Dev, Beta, Stable instead of WIF, WIS, etc.