### PR TITLE
Replaced incorrect link to release page

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -123,7 +123,7 @@
     <td>Builds Released: 24/10/2023</td>
   </tr>
   <tr>
-    <td><a href=https://github.com/YT-Advanced/releases/latest><img src="https://img.shields.io/badge/Stable%20Builds-blue?style=for-the-badge" alt="Image" height="28"></a></td>
+    <td><a href=https://github.com/YT-Advanced/WSA-Script/releases/latest><img src="https://img.shields.io/badge/Stable%20Builds-blue?style=for-the-badge" alt="Image" height="28"></a></td>
     <td>Follows the "WSA Retail Channel" <br><br> Builds are generally more stable than the builds in the "WSA Preview Program Channel" </td>
     <td>2309.40000.10.0<br></td>
     <td>Builds Released: 24/10/2023</td>


### PR DESCRIPTION
In the original README.md, the link to Stable Builds was incorrect, resulting in a 404 error. Therefore, I replaced the link.

Before: https://github.com/YT-Advanced/releases/latest
Fixed: https://github.com/YT-Advanced/WSA-Script/releases/latest

Before
![Before](https://github.com/YT-Advanced/WSA-Script/assets/42778938/0ef3f7de-17d6-4282-8b9f-75d0a0b11d88)

Fixed
![Fixed](https://github.com/YT-Advanced/WSA-Script/assets/42778938/b5619e21-a2a2-4205-b75d-6e7dcc90ede2)
